### PR TITLE
Use Supervisord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *~
 *.8
+*.log
 /.do_built
 /.do_built.dir
 /.redo

--- a/sshuttle_supervisor.conf
+++ b/sshuttle_supervisor.conf
@@ -1,0 +1,22 @@
+[unix_http_server]
+file=/tmp/sshuttle_supervisor.sock   ; (the path to the socket file)
+
+[supervisord]
+nodaemon=true                ; (start in foreground if true;default false)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/sshuttle_supervisor.sock ; use a unix:// URL  for a unix socket
+
+; Keep sshuttle running, which crashes randomly on OS X Yosemite.
+
+[program:sshuttle]
+command=%(ENV_SSHUTTLECMD)s    ; the program
+;process_name=%(program_name)s  ; process_name expr (default %(program_name)s)
+numprocs=1                      ; number of processes copies to start (def 1)
+

--- a/sshuttle_supervisor.sh
+++ b/sshuttle_supervisor.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+usage() { echo "Usage: $0 [-h <host> (REQUIRED)] [-u <username>] [-s <subnet>]" 1>&2; exit 1; }
+
+while getopts "h:u:s:" opt; do
+    case "${opt}" in
+        h)
+            host_server=${OPTARG}
+            ;;
+        u)
+            username=${OPTARG}
+            ;;
+        s)
+            subnet=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${host_server}" ]; then
+    usage
+fi
+
+if [ -n "$username" ];then
+    export SSHUTTLECMD="./sshuttle -r ${username}@${host_server} ${subnet}"
+else
+    export SSHUTTLECMD="./sshuttle -r ${host_server} ${subnet}"
+fi
+supervisord -n -c sshuttle_supervisor.conf
+


### PR DESCRIPTION
Added configuration and start script for running sshuttle with Supervisord. I found that sshuttle randomly crashed on OS X Yosemite, this turned out to be a workable solution. I made a supervisord configuration and a start script, which exports an environment variable for sshuttle_supervisor.conf to use.

Example usage: ./sshuttle_supervisor.sh -u potto -h someserver -s 10.2.0.0/16
